### PR TITLE
Dates are incorrect retrieving history

### DIFF
--- a/src/GdaxApi/GdaxApi/Utils/IDateProvider.cs
+++ b/src/GdaxApi/GdaxApi/Utils/IDateProvider.cs
@@ -18,7 +18,7 @@
 
     internal static class DateTimeExtensions
     {
-        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0);
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         public static double ToUnixTimestamp(this DateTime dateTime)
         {


### PR DESCRIPTION
- Candles returned by GetCandles have their Time set incorrectly, it is off by (local computer timezone offset) hours
- Unix Epoch is UTC and should have DateTimeKind.Utc specified so that comparison and conversion to DateTimeOffset are correct

For a unit test to show the issue (I wasn't sure if it made sense to check in a unit test for this, but I can if needed):

```
[Fact]
public void Time_kind_utc_vs_unspecified()
{
    var utc = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
    var unspecified = new DateTime(1970, 1, 1, 0, 0, 0);

    var utcOffset = new DateTimeOffset(utc);
    var unspecOffset = new DateTimeOffset(unspecified);

    Assert.Equal(utc, unspecified);
    //Assert.Equal(utc.Kind, unspecified.Kind); - Fails
    Assert.Equal(utcOffset, unspecOffset);
}
```
The equality assertion on the last line fails:
```
Assert.Equal() Failure
Expected: 1970-01-01T00:00:00.0000000+00:00
Actual:   1970-01-01T00:00:00.0000000-06:00
   at GdaxApi.Tests.TimeClientTests.Time_kind_utc_vs_unspecified() in GdaxApi\src\GdaxApi\GdaxApi.Tests\TimeClientTests.cs:line 41
```

If a DateTime is of kind Unspecified, the conversion to DateTimeOffset (and any comparisons, etc...) treat it as local.