### PR TITLE
Dependencies: Updated to Newtonsoft.Json, MS.NET.Test.Sdk

### DIFF
--- a/src/GdaxApi/GdaxApi.Tests/GdaxApi.Tests.csproj
+++ b/src/GdaxApi/GdaxApi.Tests/GdaxApi.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20171031-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/GdaxApi/GdaxApi/GdaxApi.csproj
+++ b/src/GdaxApi/GdaxApi/GdaxApi.csproj
@@ -17,7 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated Newtonsoft.Json and MS.NET.Test.Sdk to latest versions.
Microsoft.CSharp v4.4.1 was also added to the dependencies because Newtonsoft.Json v11.0.2 no longer references it as one of its dependencies with .NETStandard v2.0